### PR TITLE
README: Markdown typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Meter.configure do |config|
   config.backends << Meter::Backends::Datadog.new
   config.backends << Meter::Backends::JsonLog.new
 end
+```
 
 #### Syntax
 


### PR DESCRIPTION
This fixes a typo in the README.